### PR TITLE
Update APIManager.ts

### DIFF
--- a/src/src/engine/api/APIManager.ts
+++ b/src/src/engine/api/APIManager.ts
@@ -249,7 +249,7 @@ class APIManager extends Logger {
             .catch((error: FirebaseAuth.AuthError) => {
                 errorMessage = this.getErrorMessageFromCode(error.code);
             });
-        if (this.#auth.currentUser && createdUser) {
+        if (this.#auth.currentUser && createdUser && !errorMessage) {
             //Crée l'utilisateur dans le Firestore
             await setDoc(doc(this.#db, `employees`, createdUser.user.uid), {...employee}).catch((error) => {
                 errorMessage = this.getErrorMessageFromCode(error.code);
@@ -257,8 +257,10 @@ class APIManager extends Logger {
                     FirebaseAuth.deleteUser(this.#auth.currentUser)
                 }
             })
-            //Envoie le courriel de vérification
-            await this.verifyEmailAddress(createdUser.user);
+            if(!errorMessage){
+                //Envoie le courriel de vérification
+                errorMessage = await this.verifyEmailAddress(createdUser.user);
+            }
         }
         return errorMessage;
     }

--- a/src/src/engine/api/APIManager.ts
+++ b/src/src/engine/api/APIManager.ts
@@ -250,12 +250,15 @@ class APIManager extends Logger {
                 errorMessage = this.getErrorMessageFromCode(error.code);
             });
         if (this.#auth.currentUser && createdUser) {
+            //Crée l'utilisateur dans le Firestore
             await setDoc(doc(this.#db, `employees`, createdUser.user.uid), {...employee}).catch((error) => {
                 errorMessage = this.getErrorMessageFromCode(error.code);
                 if (this.#auth.currentUser) {
                     FirebaseAuth.deleteUser(this.#auth.currentUser)
                 }
             })
+            //Envoie le courriel de vérification
+            await this.verifyEmailAddress(createdUser.user);
         }
         return errorMessage;
     }


### PR DESCRIPTION
Ne fonctionne pas. Parce que,
Le AddEmployee login automatiquement l'admin dans le compte(auth) qu'il vient de créer.
Par la suite, _l'admin_ va essayer de créer le compte(firestore) et se fait bloqué par les rêgles de sécurités.
De plus, les rêgles de sécurités ne font pas de sens, car elles vérifient le rôle de l'employé en question(pas encore créé dans la bd) afin de valider si la requête peut passer.
Donc peu importe, les rêgles de sécurité vont bloquer la création d'employer.